### PR TITLE
Reload Frame After Foreign Function Call

### DIFF
--- a/src/Recipe.sml
+++ b/src/Recipe.sml
@@ -1,6 +1,6 @@
 Name: "wren"
 Language: "C++|0.4"
-Version: "1.0.2"
+Version: "1.0.3"
 EnableWarningsAsErrors: false
 PublicHeaders: [
 	"include/wren.h"

--- a/src/Recipe.sml
+++ b/src/Recipe.sml
@@ -1,6 +1,6 @@
 Name: "wren"
 Language: "C++|0.4"
-Version: "1.0.1"
+Version: "1.0.2"
 EnableWarningsAsErrors: false
 PublicHeaders: [
 	"include/wren.h"
@@ -13,6 +13,7 @@ IncludePaths: [
 ]
 Defines: [
 	"DEBUG"
+	"WREN_NAN_TAGGING=1"
 	"WREN_OPT_META=0"
 	"WREN_OPT_RANDOM=0"
 ]

--- a/src/vm/wren_primitive.h
+++ b/src/vm/wren_primitive.h
@@ -49,6 +49,13 @@
 #define RETURN_NUM(value)   RETURN_VAL(NUM_VAL(value))
 #define RETURN_TRUE         RETURN_VAL(TRUE_VAL)
 
+#define SET_ERROR_AND_RETURN(msg)                                              \
+    do                                                                         \
+    {                                                                          \
+      vm->fiber->error = wrenNewStringLength(vm, msg, sizeof(msg) - 1);        \
+      return;                                                                  \
+    } while (false)
+
 #define RETURN_ERROR(msg)                                                      \
     do                                                                         \
     {                                                                          \

--- a/src/vm/wren_primitive.h
+++ b/src/vm/wren_primitive.h
@@ -49,13 +49,6 @@
 #define RETURN_NUM(value)   RETURN_VAL(NUM_VAL(value))
 #define RETURN_TRUE         RETURN_VAL(TRUE_VAL)
 
-#define SET_ERROR_AND_RETURN(msg)                                              \
-    do                                                                         \
-    {                                                                          \
-      vm->fiber->error = wrenNewStringLength(vm, msg, sizeof(msg) - 1);        \
-      return;                                                                  \
-    } while (false)
-
 #define RETURN_ERROR(msg)                                                      \
     do                                                                         \
     {                                                                          \

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -829,7 +829,7 @@ inline static bool checkArity(WrenVM* vm, Value value, int numArgs)
 
 // The main bytecode interpreter loop. This is where the magic happens. It is
 // also, as you can imagine, highly performance critical.
-static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
+static WrenInterpretResult runInterpreter(WrenVM* vm, ObjFiber* fiber)
 {
   // Remember the current fiber so we can find it if a GC happens.
   vm->fiber = fiber;
@@ -838,10 +838,10 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
   // Hoist these into local variables. They are accessed frequently in the loop
   // but assigned less frequently. Keeping them in locals and updating them when
   // a call frame has been pushed or popped gives a large speed boost.
-  register CallFrame* frame;
-  register Value* stackStart;
-  register uint8_t* ip;
-  register ObjFn* fn;
+  CallFrame* frame;
+  Value* stackStart;
+  uint8_t* ip;
+  ObjFn* fn;
 
   // These macros are designed to only be invoked within this function.
   #define PUSH(value)  (*fiber->stackTop++ = value)
@@ -1907,13 +1907,13 @@ void wrenGetMapKeyValueAt(WrenVM* vm, int mapSlot,int index, int keySlot, int va
 
   if (itemIndex != usedIndex)
   {
-      RETURN_ERROR("Invalid map iterator.");
+      SET_ERROR_AND_RETURN("Invalid map iterator.");
   }
 
   MapEntry* entry = &map->entries[mapIndex];
   if (IS_UNDEFINED(entry->key))
   {
-    RETURN_ERROR("Invalid map iterator.");
+    SET_ERROR_AND_RETURN("Invalid map iterator.");
   }
 
   vm->apiStack[keySlot] = entry->key;

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -823,7 +823,7 @@ inline static bool checkArity(WrenVM* vm, Value value, int numArgs)
 
 // The main bytecode interpreter loop. This is where the magic happens. It is
 // also, as you can imagine, highly performance critical.
-static WrenInterpretResult runInterpreter(WrenVM* vm, ObjFiber* fiber)
+static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
 {
   // Remember the current fiber so we can find it if a GC happens.
   vm->fiber = fiber;
@@ -832,10 +832,10 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, ObjFiber* fiber)
   // Hoist these into local variables. They are accessed frequently in the loop
   // but assigned less frequently. Keeping them in locals and updating them when
   // a call frame has been pushed or popped gives a large speed boost.
-  CallFrame* frame;
-  Value* stackStart;
-  uint8_t* ip;
-  ObjFn* fn;
+  register CallFrame* frame;
+  register Value* stackStart;
+  register uint8_t* ip;
+  register ObjFn* fn;
 
   // These macros are designed to only be invoked within this function.
   #define PUSH(value)  (*fiber->stackTop++ = value)
@@ -1899,13 +1899,13 @@ void wrenGetMapKeyValueAt(WrenVM* vm, int mapSlot,int index, int keySlot, int va
 
   if (itemIndex != usedIndex)
   {
-      SET_ERROR_AND_RETURN("Invalid map iterator.");
+      RETURN_ERROR("Invalid map iterator.");
   }
 
   MapEntry* entry = &map->entries[mapIndex];
   if (IS_UNDEFINED(entry->key))
   {
-    SET_ERROR_AND_RETURN("Invalid map iterator.");
+    RETURN_ERROR("Invalid map iterator.");
   }
 
   vm->apiStack[keySlot] = entry->key;

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -212,13 +212,6 @@ void wrenCollectGarbage(WrenVM* vm)
 
 void* wrenReallocate(WrenVM* vm, void* memory, size_t oldSize, size_t newSize)
 {
-#if WREN_DEBUG_TRACE_MEMORY
-  // Explicit cast because size_t has different sizes on 32-bit and 64-bit and
-  // we need a consistent type for the format string.
-  printf("reallocate %p %lu -> %lu\n",
-         memory, (unsigned long)oldSize, (unsigned long)newSize);
-#endif
-
   // If new bytes are being allocated, add them to the total count. If objects
   // are being completely deallocated, we don't track that (since we don't
   // track the original size). Instead, that will be handled while marking
@@ -233,7 +226,20 @@ void* wrenReallocate(WrenVM* vm, void* memory, size_t oldSize, size_t newSize)
   if (newSize > 0 && vm->bytesAllocated > vm->nextGC) wrenCollectGarbage(vm);
 #endif
 
-  return vm->config.reallocateFn(memory, newSize, vm->config.userData);
+  void* result = vm->config.reallocateFn(memory, newSize, vm->config.userData);
+  
+#if WREN_DEBUG_TRACE_MEMORY
+  // Explicit cast because size_t has different sizes on 32-bit and 64-bit and
+  // we need a consistent type for the format string.
+  printf(
+    "reallocate %p %lu ->  %p %lu\n",
+    memory,
+    (unsigned long)oldSize,
+    result,
+    (unsigned long)newSize);
+#endif
+
+  return result;
 }
 
 // Captures the local variable [local] into an [Upvalue]. If that local is
@@ -1074,8 +1080,10 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
           break;
 
         case METHOD_FOREIGN:
+          STORE_FRAME();
           callForeign(vm, fiber, method->as.foreign, numArgs);
           if (wrenHasError(fiber)) RUNTIME_ERROR();
+          LOAD_FRAME();
           break;
 
         case METHOD_BLOCK:


### PR DESCRIPTION
There is a chance that calling a foreign function may itself allocate a new stack causing the interpreter to get out of date.